### PR TITLE
Allow setting conv.pads to length 2 list

### DIFF
--- a/operators/conv.go
+++ b/operators/conv.go
@@ -91,6 +91,10 @@ func (c *Conv) Init(attrs []*onnx.AttributeProto) error {
 			//c.Pads[i] = int(attr.Pads[2*i] + attr.Pads[2*i+1])
 			c.Pads[i] = int(attr.Pads[2*i])
 		}
+	} else if len(attr.Pads) == 2 {
+		for i := 0; i < 2; i++ {
+			c.Pads[i] = int(attr.Pads[i])
+		}
 	}
 	return nil
 }

--- a/operators/conv.go
+++ b/operators/conv.go
@@ -1,8 +1,6 @@
 package operators
 
 import (
-	"math"
-
 	onnx "github.com/owulveryck/onnx-go"
 	"gorgonia.org/gorgonia"
 	nnops "gorgonia.org/gorgonia/ops/nn"
@@ -119,10 +117,10 @@ func (c *Conv) Apply(input ...*gorgonia.Node) ([]*gorgonia.Node, error) {
 	}
 	switch c.AutoPad {
 	case "SAME_UPPER":
-		outputHeight := int(math.Ceil(float64(input[0].Shape()[2]) / float64(c.Strides[0])))
-		outputWidth := int(math.Ceil(float64(input[0].Shape()[3]) / float64(c.Strides[1])))
-		c.Pads[0] = int(math.Max(float64((outputHeight-1)*c.Strides[0]+c.KernelShape[0]-input[0].Shape()[2]), float64(0))) / 2
-		c.Pads[1] = int(math.Max(float64((outputWidth-1)*c.Strides[1]+c.KernelShape[1]-input[0].Shape()[3]), float64(0))) / 2
+		inputHeight := input[0].Shape()[2]
+		inputWidth := input[0].Shape()[3]
+		c.Pads[0] = ((inputHeight-1)*c.Strides[0] + 1 + c.Dilations[0]*(c.KernelShape[0]-1) - inputHeight) / 2
+		c.Pads[1] = ((inputWidth-1)*c.Strides[0] + 1 + c.Dilations[0]*(c.KernelShape[0]-1) - inputWidth) / 2
 	case "SAME_LOWER":
 		return nil, &onnx.ErrNotImplemented{
 			Operator:       c.name,

--- a/operators/conv_test.go
+++ b/operators/conv_test.go
@@ -1,0 +1,217 @@
+package operators
+
+import (
+	"os"
+	"testing"
+
+	onnx "github.com/owulveryck/onnx-go"
+	"github.com/stretchr/testify/assert"
+	"gorgonia.org/gorgonia"
+	"gorgonia.org/tensor"
+)
+
+func TestConv_with_strides_padding_len_2(t *testing.T) {
+	debug := os.Getenv("SKIP_NOT_IMPLEMENTED")
+	skip := true
+	if debug == "false" {
+		skip = false
+	}
+
+	assert := assert.New(t)
+
+	g := gorgonia.NewGraph()
+	op := &Conv{}
+
+	attribute0Name := "kernel_shape"
+	attribute0Type := onnx.AttributeProto_AttributeType(7)
+
+	attribute0 := &onnx.AttributeProto{
+		Name: &attribute0Name,
+		Type: &attribute0Type,
+		Ints: []int64{3, 3},
+	}
+
+	attribute1Name := "pads"
+	attribute1Type := onnx.AttributeProto_AttributeType(7)
+
+	attribute1 := &onnx.AttributeProto{
+		Name: &attribute1Name,
+		Type: &attribute1Type,
+		Ints: []int64{1, 1},
+	}
+
+	attribute2Name := "strides"
+	attribute2Type := onnx.AttributeProto_AttributeType(7)
+
+	attribute2 := &onnx.AttributeProto{
+		Name: &attribute2Name,
+		Type: &attribute2Type,
+		Ints: []int64{2, 2},
+	}
+
+	attributes := []*onnx.AttributeProto{
+		attribute0,
+		attribute1,
+		attribute2,
+	}
+
+	if len(attributes) != 0 {
+		err := op.Init(attributes)
+		t.Logf("Info: operator %#v", op)
+		if err != nil {
+			_, ok := err.(*onnx.ErrNotImplemented)
+			if ok && skip {
+				t.Skip(err)
+			}
+
+			t.Fatal(err)
+		}
+	}
+
+	x := gorgonia.NodeFromAny(g,
+		tensor.New(
+			tensor.WithShape(1, 1, 7, 5),
+			tensor.WithBacking([]float32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34})),
+		gorgonia.WithName("x"))
+
+	W := gorgonia.NodeFromAny(g,
+		tensor.New(
+			tensor.WithShape(1, 1, 3, 3),
+			tensor.WithBacking([]float32{1, 1, 1, 1, 1, 1, 1, 1, 1})),
+		gorgonia.WithName("W"))
+
+	yT := tensor.New(
+		tensor.WithShape(1, 1, 4, 3),
+		tensor.WithBacking([]float32{12, 27, 24, 63, 108, 81, 123, 198, 141, 112, 177, 124}))
+	y := new(gorgonia.Node)
+
+	o, err := op.Apply(
+		x, W,
+	)
+	if err != nil {
+		_, ok := err.(*onnx.ErrNotImplemented)
+		if ok && skip {
+			t.Skip(err)
+		}
+		_, ok = err.(*gorgonia.ErrNotImplemented)
+		if ok && skip {
+			t.Skip(err)
+		}
+
+		t.Fatal(err)
+	}
+
+	y = o[0]
+
+	machine := gorgonia.NewTapeMachine(g)
+	if err = machine.RunAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(yT.Shape(), y.Shape(), "Tensors should be the same")
+	assert.InDeltaSlice(yT.Data(), y.Value().Data(), 1e-5, "Tensors should be the same")
+
+}
+
+func TestConv_with_strides_auto_pad(t *testing.T) {
+	debug := os.Getenv("SKIP_NOT_IMPLEMENTED")
+	skip := true
+	if debug == "false" {
+		skip = false
+	}
+
+	assert := assert.New(t)
+
+	g := gorgonia.NewGraph()
+	op := &Conv{}
+
+	attribute0Name := "kernel_shape"
+	attribute0Type := onnx.AttributeProto_AttributeType(7)
+
+	attribute0 := &onnx.AttributeProto{
+		Name: &attribute0Name,
+		Type: &attribute0Type,
+		Ints: []int64{3, 3},
+	}
+
+	attribute1Name := "auto_pad"
+	attribute1Type := onnx.AttributeProto_AttributeType(3)
+
+	attribute1 := &onnx.AttributeProto{
+		Name: &attribute1Name,
+		Type: &attribute1Type,
+		S:    []byte("SAME_UPPER"),
+	}
+
+	attribute2Name := "strides"
+	attribute2Type := onnx.AttributeProto_AttributeType(7)
+
+	attribute2 := &onnx.AttributeProto{
+		Name: &attribute2Name,
+		Type: &attribute2Type,
+		Ints: []int64{2, 2},
+	}
+
+	attributes := []*onnx.AttributeProto{
+		attribute0,
+		attribute1,
+		attribute2,
+	}
+
+	if len(attributes) != 0 {
+		err := op.Init(attributes)
+		t.Logf("Info: operator %#v", op)
+		if err != nil {
+			_, ok := err.(*onnx.ErrNotImplemented)
+			if ok && skip {
+				t.Skip(err)
+			}
+
+			t.Fatal(err)
+		}
+	}
+
+	x := gorgonia.NodeFromAny(g,
+		tensor.New(
+			tensor.WithShape(1, 1, 7, 5),
+			tensor.WithBacking([]float32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34})),
+		gorgonia.WithName("x"))
+
+	W := gorgonia.NodeFromAny(g,
+		tensor.New(
+			tensor.WithShape(1, 1, 3, 3),
+			tensor.WithBacking([]float32{1, 1, 1, 1, 1, 1, 1, 1, 1})),
+		gorgonia.WithName("W"))
+
+	yT := tensor.New(
+		tensor.WithShape(1, 1, 4, 3),
+		tensor.WithBacking([]float32{12, 27, 24, 63, 108, 81, 123, 198, 141, 112, 177, 124}))
+	y := new(gorgonia.Node)
+
+	o, err := op.Apply(
+		x, W,
+	)
+	if err != nil {
+		_, ok := err.(*onnx.ErrNotImplemented)
+		if ok && skip {
+			t.Skip(err)
+		}
+		_, ok = err.(*gorgonia.ErrNotImplemented)
+		if ok && skip {
+			t.Skip(err)
+		}
+
+		t.Fatal(err)
+	}
+
+	y = o[0]
+
+	machine := gorgonia.NewTapeMachine(g)
+	if err = machine.RunAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(yT.Shape(), y.Shape(), "Tensors should be the same")
+	assert.InDeltaSlice(yT.Data(), y.Value().Data(), 1e-5, "Tensors should be the same")
+
+}

--- a/operators/conv_test.go
+++ b/operators/conv_test.go
@@ -184,8 +184,8 @@ func TestConv_with_strides_auto_pad(t *testing.T) {
 		gorgonia.WithName("W"))
 
 	yT := tensor.New(
-		tensor.WithShape(1, 1, 4, 3),
-		tensor.WithBacking([]float32{12, 27, 24, 63, 108, 81, 123, 198, 141, 112, 177, 124}))
+		tensor.WithShape(1, 1, 7, 5),
+		tensor.WithBacking([]float32{0, 0, 0, 0, 0, 0, 1, 6, 7, 0, 0, 33, 63, 51, 0, 0, 93, 153, 111, 0, 0, 153, 243, 171, 0, 0, 61, 96, 67, 0, 0, 0, 0, 0, 0}))
 	y := new(gorgonia.Node)
 
 	o, err := op.Apply(


### PR DESCRIPTION
For now conv.pads only accept length 4 list, this patch make it
accept length 2 list.

Fixes: #18